### PR TITLE
Integrate GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+name: "Docker Build Test"
+
+on: [ push ]
+
+jobs:
+  # Build the image using various configurations
+  build_docker_image:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        dotnet_tag: [ "5.0", "5.0-alpine" ]
+
+    steps:
+      -
+        name: "Checkout Sourcecode"
+        uses: actions/checkout@v2
+      -
+        name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v1
+      -
+        name: "Cache Docker layers"
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: "Build Image for .NET ${{ matrix.dotnet_tag }})"
+        uses: docker/build-push-action@v2
+        with:
+          load: true
+          tags: ci/ev-freaks/ocm-mirror:${{ matrix.dotnet_tag }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          build-args: DOTNET_TAG=${{ matrix.dotnet_tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+# see https://hub.docker.com/_/microsoft-dotnet-aspnet/ for available feature tags
+ARG DOTNET_TAG=5.0
+
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_TAG} AS base
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_TAG} AS build
 
 ARG REPO_URL=https://github.com/openchargemap/ocm-system
 ARG REPO_BRANCH=master

--- a/README.md
+++ b/README.md
@@ -32,8 +32,17 @@ To use a different repo url and branch for the "ocm-system" repository you can l
 ```bash
 docker-compose build \
   --build-arg REPO_URL=https://github.com/ev-freaks/ocm-system.git \
-  --build-arg REPO_BRANCH=testing
+  --build-arg REPO_BRANCH=testing \
 ```
+
+OR, e.g.:
+
+```bash
+docker-compose build \
+  --build-arg DOTNET_TAG=5.0-alpine
+```
+
+To use the alpine flavour of the .net docker images (smaller footprint ~ 50%)
 
 Then you should be able to perform OCM API Requests, e.g. using:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To use a different repo url and branch for the "ocm-system" repository you can l
 ```bash
 docker-compose build \
   --build-arg REPO_URL=https://github.com/ev-freaks/ocm-system.git \
-  --build-arg REPO_BRANCH=testing \
+  --build-arg REPO_BRANCH=testing
 ```
 
 OR, e.g.:

--- a/ecs/Makefile
+++ b/ecs/Makefile
@@ -6,11 +6,12 @@ APP_NAME := ocm-mirror-prod
 ECS_CLUSTER_NAME := default
 APP_SERVICE_NAME := ${APP_NAME}
 
-OCM_SYSTEM_REPO_URL := https://github.com/ev-freaks/ocm-system.git
-OCM_SYSTEM_BRANCH := testing
+# OCM_SYSTEM_REPO_URL := https://github.com/ev-freaks/ocm-system.git
+# OCM_SYSTEM_BRANCH := testing
 
-#OCM_SYSTEM_REPO_URL := https://github.com/openchargemap/ocm-system
-#OCM_SYSTEM_BRANCH := master
+OCM_SYSTEM_REPO_URL := https://github.com/openchargemap/ocm-system
+OCM_SYSTEM_BRANCH := master
+OCM_DOTNET_TAG := 5.0-alpine
 
 REPO_NAME := ocm-mirror
 REPO_URL := $(shell aws ecr describe-repositories --repository-name ${REPO_NAME} --query 'repositories[0].repositoryUri' --output text)
@@ -43,7 +44,7 @@ info:
 	$(info REPO_URL: ${REPO_URL})
 
 build-image:
-	docker build -t ${REPO_URL}:latest ${DOCKERFILE_PATH} --build-arg REPO_URL=${OCM_SYSTEM_REPO_URL} --build-arg REPO_BRANCH=${OCM_SYSTEM_BRANCH}
+	docker build -t ${REPO_URL}:latest ${DOCKERFILE_PATH} --build-arg REPO_URL=${OCM_SYSTEM_REPO_URL} --build-arg REPO_BRANCH=${OCM_SYSTEM_BRANCH} --build-arg DOTNET_TAG=${OCM_DOTNET_TAG}
 
 push-image: ecr-login
 	docker push ${REPO_URL}:${TAG}


### PR DESCRIPTION
This integrates a basic build test via GitHub actions. This also makes the .NET feature tag configurable, so one can use e.g. the alpine bases .NET docker images instead of the default one.

Also use the alpine flavour for the ECS Image.