### PR TITLE
EV-320 Streamline with Upstream Changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        dotnet_tag: [ "5.0", "5.0-alpine" ]
+        dotnet_tag: [ "6.0", "6.0-alpine" ]
 
     steps:
       -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # see https://hub.docker.com/_/microsoft-dotnet-aspnet/ for available feature tags
-ARG DOTNET_TAG=5.0
+ARG DOTNET_TAG=6.0
 
 FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_TAG} AS base
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_TAG} AS build
@@ -13,10 +13,17 @@ RUN git clone "${REPO_URL}" -b "${REPO_BRANCH}" .
 # RUN dotnet restore "API/OCM.Net/OCM.API.Worker/OCM.API.Worker.csproj"
 
 WORKDIR /src/API/OCM.Net/OCM.API.Worker
+
+# this will overwrite the existing file API/OCM.Net/OCM.API.Worker/appsettings.json
 ADD files/ .
+
 RUN dotnet build "OCM.API.Worker.csproj" -c Release -o /app/build
 
 FROM build AS publish
+
+# fix the "Found multiple publish output files with the same relative path" error
+RUN rm ../OCM.API.Web/appsettings*.json
+
 RUN dotnet publish "OCM.API.Worker.csproj" -c Release -o /app/publish
 
 FROM base AS final

--- a/ecs/Makefile
+++ b/ecs/Makefile
@@ -6,11 +6,11 @@ APP_NAME := ocm-mirror-prod
 ECS_CLUSTER_NAME := chargev-io-t4g
 APP_SERVICE_NAME := ${APP_NAME}
 
-# OCM_SYSTEM_REPO_URL := https://github.com/ev-freaks/ocm-system.git
-# OCM_SYSTEM_BRANCH := testing
+OCM_SYSTEM_REPO_URL := https://github.com/ev-freaks/ocm-system.git
+OCM_SYSTEM_BRANCH := testing
 
-OCM_SYSTEM_REPO_URL := https://github.com/openchargemap/ocm-system
-OCM_SYSTEM_BRANCH := master
+# OCM_SYSTEM_REPO_URL := https://github.com/openchargemap/ocm-system
+# OCM_SYSTEM_BRANCH := master
 OCM_DOTNET_TAG := 6.0-alpine
 
 REPO_NAME := ocm-mirror

--- a/ecs/Makefile
+++ b/ecs/Makefile
@@ -11,7 +11,7 @@ APP_SERVICE_NAME := ${APP_NAME}
 
 OCM_SYSTEM_REPO_URL := https://github.com/openchargemap/ocm-system
 OCM_SYSTEM_BRANCH := master
-OCM_DOTNET_TAG := 5.0-alpine
+OCM_DOTNET_TAG := 6.0-alpine
 
 REPO_NAME := ocm-mirror
 REPO_URL := $(shell aws ecr describe-repositories --repository-name ${REPO_NAME} --query 'repositories[0].repositoryUri' --output text)
@@ -20,7 +20,7 @@ DOCKERFILE_PATH := ..
 
 .PNONY: clean init all info build-image ecr-login create-repo reload task-definition create-service update-service register-task
 
-all: build-image push-image
+all: ecr-login buildx
 
 clean:
 	rm -rf ${TMPDIR}
@@ -43,11 +43,14 @@ init: create-repo
 info:
 	$(info REPO_URL: ${REPO_URL})
 
-build-image:
-	docker build -t ${REPO_URL}:latest ${DOCKERFILE_PATH} --build-arg REPO_URL=${OCM_SYSTEM_REPO_URL} --build-arg REPO_BRANCH=${OCM_SYSTEM_BRANCH} --build-arg DOTNET_TAG=${OCM_DOTNET_TAG}
 
-push-image: ecr-login
-	docker push ${REPO_URL}:${TAG}
+PLATFORM := linux/amd64,linux/arm64
+
+buildx-init:
+	docker buildx ls | awk '{print $1}' | grep builder &>/dev/null || docker buildx create --name builder --use && docker buildx use builder
+
+buildx: buildx-init
+	docker buildx build --push --platform ${PLATFORM} -t ${REPO_URL}:latest ${DOCKERFILE_PATH} --build-arg REPO_URL=${OCM_SYSTEM_REPO_URL} --build-arg REPO_BRANCH=${OCM_SYSTEM_BRANCH} --build-arg DOTNET_TAG=${OCM_DOTNET_TAG}
 
 ecr-login:
 	aws ecr get-login-password | docker login --username AWS --password-stdin ${REPO_URL}

--- a/ecs/Makefile
+++ b/ecs/Makefile
@@ -3,7 +3,7 @@ ifeq ($(AWS_PROFILE),)
 endif
 
 APP_NAME := ocm-mirror-prod
-ECS_CLUSTER_NAME := default
+ECS_CLUSTER_NAME := chargev-io-t4g
 APP_SERVICE_NAME := ${APP_NAME}
 
 # OCM_SYSTEM_REPO_URL := https://github.com/ev-freaks/ocm-system.git


### PR DESCRIPTION
This streamlines everything with the newest upstream changes, so everything works with the latest HEAD from upstream:

- upgrade .NET to version 6.0 (from 5.0)

Additionally this also adds arm64 support (additionally to the x84), so the image can also run on e.g. Gravitron t4g EC2 instances or M1 macs.

